### PR TITLE
Conditionally switch badges for reserved rockets

### DIFF
--- a/src/components/Rocket.jsx
+++ b/src/components/Rocket.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import Button from 'react-bootstrap/Button';
+import Badge from 'react-bootstrap/Badge';
 import { useDispatch } from 'react-redux';
 import { reserveRocket } from '../redux/rockets/rocketsSlice';
 
@@ -16,9 +17,20 @@ const Rocket = ({ rocket }) => {
       <div className="rocket-detail">
         <h2>{rocket.rocket_name}</h2>
         <p>
+          {rocket.reserved && (
+            <Badge bg="info">
+              Reserved
+            </Badge>
+          )}
           {rocket.description}
         </p>
-        <Button variant="primary" onClick={handleReservation}>Reserve Rocket</Button>
+        {
+          rocket.reserved
+            ? <Button variant="outline-secondary" onClick={handleReservation}>Cancel reservation</Button>
+            : <Button variant="primary" onClick={handleReservation}>Reserve Rocket</Button>
+        }
+        {' '}
+
       </div>
     </div>
   );
@@ -29,6 +41,7 @@ Rocket.propTypes = {
     rocket_name: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     flickr_images: PropTypes.arrayOf(PropTypes.string).isRequired,
+    reserved: PropTypes.bool.isRequired,
   }).isRequired,
 };
 export default Rocket;


### PR DESCRIPTION
## Changes made ✍️ 

- Rockets that have already been reserved now show a "Reserved" badge and a "Cancel reservation" button instead of the default "Reserve rocket".